### PR TITLE
mxdev config: Fix debug mode in instance.yaml.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 2.0.2 (2024-xx-xx)
 ------------------
 
+- mxdev config: Fix debug mode in instance.yaml. Debug mode must be set as `"True"` or `"False"`, not `on` or `off`.
+  [thet]
+
 - Documentation: Clarify procedure to update/initialize the Open-/ElasticSearch with data. [jensens]
 
 

--- a/instance.yaml
+++ b/instance.yaml
@@ -10,7 +10,7 @@ default_context:
     wsgi_fast_listen: 0.0.0.0:8080
     initial_user_name: admin
     initial_user_password: admin
-    debug_mode: on
+    debug_mode: "True"
     load_zcml:
         package_includes: ["collective.elastic.plone",]
     db_storage: direct


### PR DESCRIPTION
Debug mode must be set as "True" or "False", not on or off.